### PR TITLE
Update `handler.RouteHandler` to use `log/slog` 

### DIFF
--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/aaronland/go-http-server"
-	"github.com/aaronland/go-http-server/handler"
+	"github.com/aaronland/go-http-server/v2"
+	"github.com/aaronland/go-http-server/v2/handler"
 	"github.com/sfomuseum/go-flags/flagset"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/aaronland/go-http-server
+module github.com/aaronland/go-http-server/v2
 
-go 1.22
+go 1.23.3
 
 require (
 	github.com/aaronland/go-roster v1.0.0

--- a/handler/route_test.go
+++ b/handler/route_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/aaronland/go-http-server"
+	"github.com/aaronland/go-http-server/v2"
 )
 
 func TestRouteHandler(t *testing.T) {


### PR DESCRIPTION
* Update `handler.RouteHandler` to use `log/slog` (replacing `log.Logger` stuff)
* Bump to `v2`